### PR TITLE
FIX: Java 9+ ConcurrentModificationExc when initializing ViewScope Views

### DIFF
--- a/src/main/java/com/vaadin/guice/server/UIScope.java
+++ b/src/main/java/com/vaadin/guice/server/UIScope.java
@@ -33,8 +33,14 @@ class UIScope implements Scope {
             Map<UI, Map<Key<?>, Object>> uisToScopedObjects = scopesBySession.computeIfAbsent(vaadinSession, session -> new WeakHashMap<>());
 
             final Map<Key<?>, Object> scopedObjects = getScopedObjects(uisToScopedObjects);
-
-            return (T) scopedObjects.computeIfAbsent(key, k -> provider.get());
+            
+            if(scopedObjects.containsValue(key)) {
+                return (T) scopedObjects.get(key);
+            }
+            
+            T result = provider.get();
+            scopedObjects.put(key, result);
+            return result;
         };
     }
 


### PR DESCRIPTION
Java 9/10/11 compatibility: behavior of HashMap::computeIfAbsent() has changed since Java 9
"ConcurrentModificationException - if it is detected that the mapping function modified this map"

When working with ViewScope-Views (injected into UIScope Components) a ConcurrentModificationException was thrown. (because of the change of the map inside the mappingfunction)
This patch fixes this problem.